### PR TITLE
afk resume excuse

### DIFF
--- a/src/main/java/com/jannik_kuehn/loritime/bukkit/listener/BukkitPlayerAfkListener.java
+++ b/src/main/java/com/jannik_kuehn/loritime/bukkit/listener/BukkitPlayerAfkListener.java
@@ -60,7 +60,10 @@ public class BukkitPlayerAfkListener implements Listener {
     }
 
     @EventHandler(ignoreCancelled = true)
-    public void onPlayerCommandEvent(PlayerCommandPreprocessEvent event) {
+    public void onPlayerCommand(PlayerCommandPreprocessEvent event) {
+        if (event.getMessage().equalsIgnoreCase("/afk")) {
+            return;
+        }
         LoriTimePlayer player = new LoriTimePlayer(event.getPlayer().getUniqueId(), event.getPlayer().getName());
         updateAfkStatus(getOrCreatePlayer(event.getPlayer().getUniqueId(), player));
     }


### PR DESCRIPTION
BukkitPlayerAfkListener#onPlayerCommand does not reset the time trigger for player, if he executes the command `/afk`