### PR TITLE
Command Completion perm fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Removed
 ### Fixed
 - Corrected documentation to show Java 21 and Minecraft 1.21+ compatibility.
+- Fixed command completions suggesting scoped `/lt` lookup arguments or AFK player targets that the sender cannot execute.
 ### Security
 
 ## [2.0.0] - 2026-07-01

--- a/common/src/main/java/com/jannik_kuehn/common/command/LoriTimeAfkCommand.java
+++ b/common/src/main/java/com/jannik_kuehn/common/command/LoriTimeAfkCommand.java
@@ -2,7 +2,6 @@ package com.jannik_kuehn.common.command;
 
 import com.jannik_kuehn.common.LoriTimePlugin;
 import com.jannik_kuehn.common.command.core.CommandMessages;
-import com.jannik_kuehn.common.command.core.PlayerNameCompletions;
 import com.jannik_kuehn.common.config.localization.Localization;
 import com.jannik_kuehn.common.platform.CommonCommand;
 import com.jannik_kuehn.common.platform.CommonPlayerSender;
@@ -15,7 +14,6 @@ import java.util.stream.Collectors;
 /**
  * Command that toggles the sender's AFK state.
  */
-@SuppressWarnings("PMD.AvoidLiteralsInIfCondition")
 public class LoriTimeAfkCommand implements CommonCommand {
 
     /**
@@ -69,12 +67,6 @@ public class LoriTimeAfkCommand implements CommonCommand {
      */
     @Override
     public List<String> handleTabComplete(final CommonSender source, final String... args) {
-        if (args.length == 0) {
-            return PlayerNameCompletions.online(plugin, "");
-        }
-        if (args.length == 1) {
-            return PlayerNameCompletions.online(plugin, args[0]);
-        }
         return List.of();
     }
 

--- a/common/src/main/java/com/jannik_kuehn/common/command/core/LookupScopeSuggestions.java
+++ b/common/src/main/java/com/jannik_kuehn/common/command/core/LookupScopeSuggestions.java
@@ -26,25 +26,38 @@ final class LookupScopeSuggestions {
     /* default */ static List<String> suggest(final CommonSender source, final String argument,
                                               final boolean includeTimeRange,
                                               final boolean requireScopePermissions) {
+        return suggest(source, argument, includeTimeRange, requireScopePermissions, true);
+    }
+
+    /* default */ static List<String> suggest(final CommonSender source, final String argument,
+                                              final boolean includeTimeRange,
+                                              final boolean requireScopePermissions,
+                                              final boolean selfLookup) {
         final String lowerArgument = argument.toLowerCase(Locale.ROOT);
         final List<String> suggestions = new ArrayList<>();
-        suggestServer(source, lowerArgument, requireScopePermissions, suggestions);
-        suggestWorld(source, lowerArgument, requireScopePermissions, suggestions);
-        suggestTimeRange(source, lowerArgument, includeTimeRange, requireScopePermissions, suggestions);
+        suggestServer(source, lowerArgument, requireScopePermissions, selfLookup, suggestions);
+        suggestWorld(source, lowerArgument, requireScopePermissions, selfLookup, suggestions);
+        suggestTimeRange(source, lowerArgument, includeTimeRange, requireScopePermissions, selfLookup, suggestions);
         return suggestions;
     }
 
     private static void suggestServer(final CommonSender source, final String lowerArgument,
-                                      final boolean requireScopePermissions, final List<String> suggestions) {
-        if ((!requireScopePermissions || source.hasPermission("loritime.see.server"))
+                                      final boolean requireScopePermissions,
+                                      final boolean selfLookup,
+                                      final List<String> suggestions) {
+        final String permission = selfLookup ? "loritime.see.server" : "loritime.see.server.other";
+        if ((!requireScopePermissions || source.hasPermission(permission))
                 && CommandScopes.SERVER_PREFIX.startsWith(lowerArgument)) {
             suggestions.add(CommandScopes.SERVER_PREFIX);
         }
     }
 
     private static void suggestWorld(final CommonSender source, final String lowerArgument,
-                                     final boolean requireScopePermissions, final List<String> suggestions) {
-        if ((!requireScopePermissions || source.hasPermission("loritime.see.world"))
+                                     final boolean requireScopePermissions,
+                                     final boolean selfLookup,
+                                     final List<String> suggestions) {
+        final String permission = selfLookup ? "loritime.see.world" : "loritime.see.world.other";
+        if ((!requireScopePermissions || source.hasPermission(permission))
                 && CommandScopes.WORLD_PREFIX.startsWith(lowerArgument)) {
             suggestions.add(CommandScopes.WORLD_PREFIX);
         }
@@ -53,16 +66,19 @@ final class LookupScopeSuggestions {
     private static void suggestTimeRange(final CommonSender source, final String lowerArgument,
                                          final boolean includeTimeRange,
                                          final boolean requireScopePermissions,
+                                         final boolean selfLookup,
                                          final List<String> suggestions) {
-        if (includeTimeRange && canSuggestTimeRange(source, requireScopePermissions)
+        if (includeTimeRange && canSuggestTimeRange(source, requireScopePermissions, selfLookup)
                 && CommandScopes.TIME_PREFIX.startsWith(lowerArgument)) {
             suggestions.add(CommandScopes.TIME_PREFIX);
         }
     }
 
-    private static boolean canSuggestTimeRange(final CommonSender source, final boolean requireScopePermissions) {
+    private static boolean canSuggestTimeRange(final CommonSender source,
+                                               final boolean requireScopePermissions,
+                                               final boolean selfLookup) {
+        final String permission = selfLookup ? "loritime.see.timerange" : "loritime.see.timerange.other";
         return !requireScopePermissions
-                || source.hasPermission("loritime.see.timerange")
-                || source.hasPermission("loritime.see.timerange.other");
+                || source.hasPermission(permission);
     }
 }

--- a/common/src/main/java/com/jannik_kuehn/common/command/core/LoriTimeLookupCompletions.java
+++ b/common/src/main/java/com/jannik_kuehn/common/command/core/LoriTimeLookupCompletions.java
@@ -13,6 +13,7 @@ import java.util.UUID;
 /**
  * Live completion source for `/loritime` lookup flags.
  */
+@SuppressWarnings("PMD.TooManyMethods")
 public final class LoriTimeLookupCompletions {
 
     /**
@@ -64,6 +65,7 @@ public final class LoriTimeLookupCompletions {
      * @param args current command arguments
      * @return matching completions
      */
+    @SuppressWarnings({"PMD.CognitiveComplexity", "PMD.CyclomaticComplexity"})
     public List<String> suggest(final CommonSender source, final String... args) {
         if (args.length == 0) {
             return suggestArgument(source, "", args);
@@ -71,15 +73,27 @@ public final class LoriTimeLookupCompletions {
         final String argument = args[args.length - 1];
         final String lowerArgument = argument.toLowerCase(Locale.ROOT);
         if (lowerArgument.startsWith(CommandScopes.SERVER_PREFIX)) {
+            if (!canSuggestServerValues(source, args)) {
+                return List.of();
+            }
             return suggestServerValues(CommandScopes.SERVER_PREFIX, argument);
         }
         if (lowerArgument.startsWith(CommandScopes.SHORT_SERVER_PREFIX)) {
+            if (!canSuggestServerValues(source, args)) {
+                return List.of();
+            }
             return suggestServerValues(CommandScopes.SHORT_SERVER_PREFIX, argument);
         }
         if (lowerArgument.startsWith(CommandScopes.WORLD_PREFIX)) {
+            if (!canSuggestWorldValues(source, args)) {
+                return List.of();
+            }
             return suggestWorldValues(source, CommandScopes.WORLD_PREFIX, argument, args);
         }
         if (lowerArgument.startsWith(CommandScopes.SHORT_WORLD_PREFIX)) {
+            if (!canSuggestWorldValues(source, args)) {
+                return List.of();
+            }
             return suggestWorldValues(source, CommandScopes.SHORT_WORLD_PREFIX, argument, args);
         }
         if (includeTimeRange
@@ -93,7 +107,7 @@ public final class LoriTimeLookupCompletions {
     private List<String> suggestArgument(final CommonSender source, final String argument, final String... args) {
         final String[] previousArgs = args.length == 0 ? args : Arrays.copyOf(args, args.length - 1);
         final List<String> suggestions = LookupScopeSuggestions.suggest(source, argument,
-                includeTimeRange, requireScopePermissions);
+                includeTimeRange, requireScopePermissions, isSelfLookup(source, previousArgs));
         if (findFlagValue(previousArgs, CommandScopes.SERVER_PREFIX, CommandScopes.SHORT_SERVER_PREFIX).isPresent()) {
             suggestions.remove(CommandScopes.SERVER_PREFIX);
         }
@@ -108,6 +122,18 @@ public final class LoriTimeLookupCompletions {
             suggestions.addAll(0, PlayerNameCompletions.suggest(plugin, argument));
         }
         return suggestions;
+    }
+
+    private boolean canSuggestServerValues(final CommonSender source, final String... args) {
+        return !requireScopePermissions || source.hasPermission(isSelfLookup(source, args)
+                ? "loritime.see.server"
+                : "loritime.see.server.other");
+    }
+
+    private boolean canSuggestWorldValues(final CommonSender source, final String... args) {
+        return !requireScopePermissions || source.hasPermission(isSelfLookup(source, args)
+                ? "loritime.see.world"
+                : "loritime.see.world.other");
     }
 
     private List<String> suggestServerValues(final String prefix, final String argument) {
@@ -154,6 +180,26 @@ public final class LoriTimeLookupCompletions {
 
     private boolean hasPlayerToken(final String... args) {
         return Arrays.stream(args).anyMatch(argument -> !argument.contains(":"));
+    }
+
+    private boolean isSelfLookup(final CommonSender source, final String... args) {
+        if (!(source instanceof final CommonPlayerSender playerSender)) {
+            return false;
+        }
+        final Optional<String> playerToken = Arrays.stream(args)
+                .filter(argument -> !argument.contains(":"))
+                .findFirst();
+        if (playerToken.isEmpty()) {
+            return true;
+        }
+        if (playerToken.get().equalsIgnoreCase(playerSender.getName())) {
+            return true;
+        }
+        final UUID sourceUniqueId = playerSender.getUniqueId();
+        return sourceUniqueId != null && plugin.getServer().getPlayer(playerToken.get())
+                .map(CommonPlayerSender::getUniqueId)
+                .filter(sourceUniqueId::equals)
+                .isPresent();
     }
 
     private boolean startsWithIgnoreCase(final String value, final String prefix) {

--- a/common/src/test/java/com/jannik_kuehn/common/command/LoriTimeCompletionTest.java
+++ b/common/src/test/java/com/jannik_kuehn/common/command/LoriTimeCompletionTest.java
@@ -197,6 +197,7 @@ class LoriTimeCompletionTest {
     @Test
     void loriTimeTabCompletionUsesLiveServerCandidatesWithoutStorageLookup() throws StorageException {
         final CompletionContext context = new CompletionContext();
+        when(context.source.hasPermission("loritime.see.server")).thenReturn(true);
         when(context.server.getLiveServerNames()).thenReturn(List.of("survival", "creative"));
 
         final LoriTimeCommand command = new LoriTimeCommand(context.plugin, context.localization);
@@ -209,6 +210,7 @@ class LoriTimeCompletionTest {
     @Test
     void loriTimeTabCompletionUsesLiveWorldCandidatesWithoutStorageLookup() throws StorageException {
         final CompletionContext context = new CompletionContext();
+        when(context.source.hasPermission("loritime.see.world")).thenReturn(true);
         when(context.server.getLiveWorldNames(Optional.of("survival"), Optional.empty()))
                 .thenReturn(List.of("world", "world_nether"));
 
@@ -224,6 +226,7 @@ class LoriTimeCompletionTest {
     void loriTimeTabCompletionUsesCachedServerCandidatesForShortFlags() throws StorageException {
         final CompletionContext context = new CompletionContext();
         context.scopeCache.replaceStoredNames(Set.of("survival", "creative"), Set.of("world", "world_nether"));
+        when(context.source.hasPermission("loritime.see.server")).thenReturn(true);
         when(context.server.getLiveServerNames()).thenReturn(List.of());
 
         final LoriTimeCommand command = new LoriTimeCommand(context.plugin, context.localization);
@@ -237,6 +240,7 @@ class LoriTimeCompletionTest {
     void loriTimeTabCompletionUsesCachedWorldCandidatesForShortFlags() throws StorageException {
         final CompletionContext context = new CompletionContext();
         context.scopeCache.replaceStoredNames(Set.of("survival", "creative"), Set.of("world", "world_nether"));
+        when(context.source.hasPermission("loritime.see.world")).thenReturn(true);
         when(context.server.getLiveWorldNames(Optional.of("survival"), Optional.empty())).thenReturn(List.of());
 
         final LoriTimeCommand command = new LoriTimeCommand(context.plugin, context.localization);
@@ -244,6 +248,87 @@ class LoriTimeCompletionTest {
         assertEquals(List.of("w:world", "w:world_nether"), command.handleTabComplete(context.source, "s:survival", "w:wo"),
                 "Expected short world flag values from the cached scope names");
         verifyNoSuggestionStorageLookup(context.storage);
+    }
+
+    @Test
+    void loriTimeTabCompletionHidesOtherPlayerServerPrefixWithoutOtherPermission() throws StorageException {
+        final CompletionContext context = new CompletionContext();
+        when(context.source.hasPermission("loritime.see.server")).thenReturn(true);
+
+        final LoriTimeCommand command = new LoriTimeCommand(context.plugin, context.localization);
+
+        assertEquals(List.of(), command.handleTabComplete(context.source, "Lorias_", "s"),
+                "Expected other-player server prefix to require other server permission");
+        verifyNoSuggestionStorageLookup(context.storage);
+    }
+
+    @Test
+    void loriTimeTabCompletionHidesOtherPlayerServerValuesWithoutOtherPermission() throws StorageException {
+        final CompletionContext context = new CompletionContext();
+        when(context.source.hasPermission("loritime.see.server")).thenReturn(true);
+        when(context.server.getLiveServerNames()).thenReturn(List.of("survival", "creative"));
+
+        final LoriTimeCommand command = new LoriTimeCommand(context.plugin, context.localization);
+
+        assertEquals(List.of(), command.handleTabComplete(context.source, "Lorias_", "server:su"),
+                "Expected other-player server values to require other server permission");
+        verifyNoSuggestionStorageLookup(context.storage);
+    }
+
+    @Test
+    void loriTimeTabCompletionSuggestsOtherPlayerServerScopeWithOtherPermission() {
+        final CompletionContext context = new CompletionContext();
+        when(context.source.hasPermission("loritime.see.server.other")).thenReturn(true);
+        when(context.server.getLiveServerNames()).thenReturn(List.of("survival", "creative"));
+
+        final LoriTimeCommand command = new LoriTimeCommand(context.plugin, context.localization);
+
+        assertEquals(List.of("server:"), command.handleTabComplete(context.source, "Lorias_", "s"),
+                "Expected other-player server prefix with other server permission");
+        assertEquals(List.of("server:survival"), command.handleTabComplete(context.source, "Lorias_", "server:su"),
+                "Expected other-player server values with other server permission");
+    }
+
+    @Test
+    void loriTimeTabCompletionHidesOtherPlayerWorldPrefixWithoutOtherPermission() throws StorageException {
+        final CompletionContext context = new CompletionContext();
+        when(context.source.hasPermission("loritime.see.world")).thenReturn(true);
+
+        final LoriTimeCommand command = new LoriTimeCommand(context.plugin, context.localization);
+
+        assertEquals(List.of(), command.handleTabComplete(context.source, "Lorias_", "w"),
+                "Expected other-player world prefix to require other world permission");
+        verifyNoSuggestionStorageLookup(context.storage);
+    }
+
+    @Test
+    void loriTimeTabCompletionHidesOtherPlayerWorldValuesWithoutOtherPermission() throws StorageException {
+        final CompletionContext context = new CompletionContext();
+        when(context.source.hasPermission("loritime.see.world")).thenReturn(true);
+        when(context.server.getLiveWorldNames(Optional.of("survival"), Optional.empty()))
+                .thenReturn(List.of("world", "world_nether"));
+
+        final LoriTimeCommand command = new LoriTimeCommand(context.plugin, context.localization);
+
+        assertEquals(List.of(), command.handleTabComplete(context.source, "Lorias_", "server:survival", "world:wo"),
+                "Expected other-player world values to require other world permission");
+        verifyNoSuggestionStorageLookup(context.storage);
+    }
+
+    @Test
+    void loriTimeTabCompletionSuggestsOtherPlayerWorldScopeWithOtherPermission() {
+        final CompletionContext context = new CompletionContext();
+        when(context.source.hasPermission("loritime.see.world.other")).thenReturn(true);
+        when(context.server.getLiveWorldNames(Optional.of("survival"), Optional.empty()))
+                .thenReturn(List.of("world", "world_nether"));
+
+        final LoriTimeCommand command = new LoriTimeCommand(context.plugin, context.localization);
+
+        assertEquals(List.of("world:"), command.handleTabComplete(context.source, "Lorias_", "w"),
+                "Expected other-player world prefix with other world permission");
+        assertEquals(List.of("world:world", "world:world_nether"),
+                command.handleTabComplete(context.source, "Lorias_", "server:survival", "world:wo"),
+                "Expected other-player world values with other world permission");
     }
 
     @Test
@@ -274,6 +359,24 @@ class LoriTimeCompletionTest {
     }
 
     @Test
+    void loriTimeTabCompletionUsesOtherTimeRangePermissionForOtherPlayerLookup() {
+        final CompletionContext context = new CompletionContext();
+        when(context.plugin.getKnownPlayerNames()).thenReturn(Set.of());
+        when(context.plugin.getRecentPlayerSuggestionCache()).thenReturn(null);
+        when(context.server.getOnlinePlayers()).thenReturn(new CommonPlayerSender[0]);
+        when(context.source.hasPermission("loritime.see.timerange")).thenReturn(true);
+
+        final LoriTimeCommand command = new LoriTimeCommand(context.plugin, context.localization);
+
+        assertEquals(List.of(), command.handleTabComplete(context.source, "Lorias_", "t"),
+                "Expected other-player time range prefix to ignore self ranged permission");
+
+        when(context.source.hasPermission("loritime.see.timerange.other")).thenReturn(true);
+        assertEquals(List.of("time:"), command.handleTabComplete(context.source, "Lorias_", "t"),
+                "Expected other-player time range prefix with other ranged permission");
+    }
+
+    @Test
     void loriTimeTabCompletionDoesNotSuggestTimeValuesOrDuplicateTimeFlag() {
         final CompletionContext context = new CompletionContext();
         when(context.plugin.getKnownPlayerNames()).thenReturn(Set.of());
@@ -286,6 +389,48 @@ class LoriTimeCompletionTest {
                 "Expected no custom time range value suggestions");
         assertEquals(List.of(), command.handleTabComplete(context.source, "t:3d", "t"),
                 "Expected no duplicate time flag suggestion");
+    }
+
+    @Test
+    void modifyTabCompletionKeepsScopePrefixSuggestionsWithoutReadPermissions() throws StorageException {
+        final CompletionContext context = new CompletionContext();
+        when(context.source.hasPermission("loritime.admin")).thenReturn(true);
+
+        final LoriTimeModifyCommand command = new LoriTimeModifyCommand(context.plugin, context.localization,
+                mock(TimeParser.class));
+
+        assertEquals(List.of("server:"), command.handleTabComplete(context.source, "add", "Lorias_", "12", "s"),
+                "Expected admin modify prefix completion without read scope permissions");
+        verifyNoSuggestionStorageLookup(context.storage);
+    }
+
+    @Test
+    void modifyTabCompletionKeepsScopeValueSuggestionsWithoutReadPermissions() throws StorageException {
+        final CompletionContext context = new CompletionContext();
+        when(context.source.hasPermission("loritime.admin")).thenReturn(true);
+        when(context.server.getLiveServerNames()).thenReturn(List.of("survival", "creative"));
+
+        final LoriTimeModifyCommand command = new LoriTimeModifyCommand(context.plugin, context.localization,
+                mock(TimeParser.class));
+
+        assertEquals(List.of("server:survival"), command.handleTabComplete(context.source, "add", "Lorias_", "12", "server:su"),
+                "Expected admin modify value completion without read scope permissions");
+        verifyNoSuggestionStorageLookup(context.storage);
+    }
+
+    @Test
+    void afkTabCompletionDoesNotSuggestPlayerTargets() {
+        final CompletionContext context = new CompletionContext();
+        final CommonPlayerSender onlinePlayer = mock(CommonPlayerSender.class);
+        when(context.server.getOnlinePlayers()).thenReturn(new CommonPlayerSender[]{onlinePlayer});
+        when(onlinePlayer.getName()).thenReturn("OnlineUser");
+
+        final LoriTimeAfkCommand command = new LoriTimeAfkCommand(context.plugin, context.localization);
+
+        assertEquals(List.of(), command.handleTabComplete(context.source),
+                "Expected AFK completion to stay empty for self-only command");
+        assertEquals(List.of(), command.handleTabComplete(context.source, "O"),
+                "Expected AFK completion not to suggest player targets");
     }
 
     private void verifyNoSuggestionStorageLookup(final UnifiedStorage storage) throws StorageException {
@@ -316,6 +461,7 @@ class LoriTimeCompletionTest {
             when(plugin.getServer()).thenReturn(server);
             when(plugin.getPlayerConverter()).thenReturn(mock(LoriTimePlayerConverter.class));
             when(plugin.getScopeSuggestionCache()).thenReturn(scopeCache);
+            when(source.getName()).thenReturn("SourcePlayer");
         }
     }
 }


### PR DESCRIPTION
# Description
Restrict command completions to only suggest accessible scope and player options; add tests for permissions-based filtering.


## Related Issues
<!-- Issue number if existing. -->
Closes #XXXX

## Checklists
Run maven Verify in your IDE and ensure it SUCCEEDS!

### Did you...
<!-- Check these things before posting the pull request: -->
- [ ]  ... test your changes?
- [ ]  ... solve all TODOs?
- [ ]  ... remove any commented out code?
- [ ]  ... update the changelog?
- [ ]  ... update the documentation?

Check if the build pipeline succeeded for this PR!
